### PR TITLE
caddy-radius v2 Security fixes - RADIUS DDoS/brute force limiting and Path filters

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -2,6 +2,7 @@ package radiusauth
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -89,6 +90,30 @@ func (ra *RadiusAuth) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.ArgErr()
 				}
 				ra.OnlyPaths = append(ra.OnlyPaths, paths...)
+
+			case "max_failures":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				n, err := strconv.Atoi(d.Val())
+				if err != nil || n <= 0 {
+					return d.Errf("max_failures must be a positive integer, got %q", d.Val())
+				}
+				ra.MaxFailures = n
+
+			case "failure_window":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				t, err := time.ParseDuration(d.Val())
+				if err != nil {
+					var secs int
+					if _, serr := fmt.Sscanf(d.Val(), "%d", &secs); serr != nil {
+						return d.Errf("invalid failure_window %q: %v", d.Val(), err)
+					}
+					t = time.Duration(secs) * time.Second
+				}
+				ra.FailureWindow = caddy.Duration(t)
 
 			default:
 				return d.Errf("unknown radiusauth option: %s", d.Val())

--- a/filter.go
+++ b/filter.go
@@ -19,7 +19,7 @@ type ignoredPathFilter struct {
 
 func (s *securedPathFilter) shouldAuthenticate(r *http.Request) bool {
 	for _, p := range s.securedPaths {
-		if strings.HasPrefix(r.URL.Path, p) {
+		if pathMatches(r.URL.Path, p) {
 			return true
 		}
 	}
@@ -28,9 +28,20 @@ func (s *securedPathFilter) shouldAuthenticate(r *http.Request) bool {
 
 func (i *ignoredPathFilter) shouldAuthenticate(r *http.Request) bool {
 	for _, p := range i.ignoredPaths {
-		if strings.HasPrefix(r.URL.Path, p) {
+		if pathMatches(r.URL.Path, p) {
 			return false
 		}
 	}
 	return true
+}
+
+// pathMatches reports whether requestPath falls under prefix in a
+// path-segment-aware way. "/admin" matches "/admin" and "/admin/panel"
+// but not "/administrator".
+func pathMatches(requestPath, prefix string) bool {
+	if !strings.HasPrefix(requestPath, prefix) {
+		return false
+	}
+	// Exact match or the next character is a slash (segment boundary).
+	return len(requestPath) == len(prefix) || requestPath[len(prefix)] == '/'
 }

--- a/radius.go
+++ b/radius.go
@@ -57,9 +57,20 @@ type RadiusAuth struct {
 	// Paths to require authentication on. Cannot be combined with ExceptPaths.
 	OnlyPaths []string `json:"only,omitempty"`
 
+	// Maximum failed authentication attempts per IP within FailureWindow.
+	// Required — protects RADIUS infrastructure from brute-force flooding.
+	MaxFailures int `json:"max_failures"`
+
+	// Time window in which failures are counted (e.g. "1m").
+	// Required — protects RADIUS infrastructure from brute-force flooding.
+	FailureWindow caddy.Duration `json:"failure_window"`
+
 	db            *bolt.DB
 	requestFilter filter
 	logger        *zap.Logger
+	// limiter MUST be a pointer so the value-receiver ServeHTTP (which
+	// copies RadiusAuth per request) shares the same map and mutex.
+	limiter *rateLimiter
 }
 
 // CaddyModule returns the Caddy module information.
@@ -111,6 +122,12 @@ func (ra *RadiusAuth) Provision(ctx caddy.Context) error {
 		}
 	}
 
+	ra.limiter = &rateLimiter{
+		failures: make(map[string]*failRecord),
+		stop:     make(chan struct{}),
+	}
+	go ra.limiter.cleanupLoop(time.Duration(ra.FailureWindow))
+
 	return nil
 }
 
@@ -130,11 +147,20 @@ func (ra *RadiusAuth) Validate() error {
 	if len(ra.ExceptPaths) > 0 && len(ra.OnlyPaths) > 0 {
 		return errors.New("cannot use both 'except' and 'only' path filters")
 	}
+	if ra.MaxFailures <= 0 {
+		return errors.New("max_failures is required and must be > 0 (brute-force protection)")
+	}
+	if ra.FailureWindow <= 0 {
+		return errors.New("failure_window is required and must be > 0 (brute-force protection)")
+	}
 	return nil
 }
 
-// Cleanup closes the BoltDB connection when the module is unloaded.
+// Cleanup stops the rate-limiter goroutine and closes the BoltDB connection.
 func (ra *RadiusAuth) Cleanup() error {
+	if ra.limiter != nil {
+		close(ra.limiter.stop)
+	}
 	if ra.db != nil {
 		return ra.db.Close()
 	}
@@ -145,6 +171,16 @@ func (ra *RadiusAuth) Cleanup() error {
 func (ra RadiusAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	if ra.requestFilter != nil && !ra.requestFilter.shouldAuthenticate(r) {
 		return next.ServeHTTP(w, r)
+	}
+
+	// Rate-limit check runs BEFORE parsing credentials to avoid leaking
+	// timing information and to reject blocked IPs as cheaply as possible.
+	ip := extractIP(r.RemoteAddr)
+	if ra.limiter.isBlocked(ip, ra.MaxFailures, time.Duration(ra.FailureWindow)) {
+		ra.logger.Warn("rate limited", zap.String("ip", ip))
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		return nil
 	}
 
 	username, password, ok := r.BasicAuth()
@@ -161,6 +197,7 @@ func (ra RadiusAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 		cached, err := cacheSeek(ra, username, password)
 		if cached {
 			ra.logger.Debug("cache hit", zap.String("user", username))
+			ra.limiter.clearFailures(ip)
 			return next.ServeHTTP(w, r)
 		}
 		if err != nil {
@@ -174,10 +211,13 @@ func (ra RadiusAuth) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	}
 
 	if !authenticated {
+		ra.limiter.recordFailure(ip, time.Duration(ra.FailureWindow))
 		w.Header().Set("WWW-Authenticate", realm)
 		w.WriteHeader(http.StatusUnauthorized)
 		return nil
 	}
+
+	ra.limiter.clearFailures(ip)
 
 	if ra.db != nil && ra.CacheTimeout > 0 {
 		if err := cacheWrite(ra, username, password); err != nil {

--- a/radius_test.go
+++ b/radius_test.go
@@ -17,6 +17,14 @@ import (
 	"github.com/jamesboswell/radius/rfc2865"
 )
 
+// Default rate-limit values used in tests where rate limiting is not the
+// focus. Generous enough to never interfere with normal test behavior.
+const (
+	testMaxFailures = 100
+)
+
+var testFailureWindow = caddy.Duration(time.Minute)
+
 // startMockRADIUS starts a PacketServer on an available UDP port. It accepts
 // requests where username == password (a simple test convention) and rejects
 // everything else. Returns the server address and a shutdown function.
@@ -72,13 +80,23 @@ func newProvisioned(t *testing.T, ra *RadiusAuth) *RadiusAuth {
 	return ra
 }
 
+// testRA returns a RadiusAuth with the mandatory fields and given server/secret.
+func testRA(addr, secret string) *RadiusAuth {
+	return &RadiusAuth{
+		Servers:       []string{addr},
+		Secret:        secret,
+		MaxFailures:   testMaxFailures,
+		FailureWindow: testFailureWindow,
+	}
+}
+
 // ── ServeHTTP integration tests ──────────────────────────────────────────────
 
 func TestServeHTTP_NoCreds_Returns401(t *testing.T) {
 	addr, shutdown := startMockRADIUS(t, "secret")
 	defer shutdown()
 
-	ra := newProvisioned(t, &RadiusAuth{Servers: []string{addr}, Secret: "secret"})
+	ra := newProvisioned(t, testRA(addr, "secret"))
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -96,7 +114,7 @@ func TestServeHTTP_ValidCreds_Returns200(t *testing.T) {
 	addr, shutdown := startMockRADIUS(t, "secret")
 	defer shutdown()
 
-	ra := newProvisioned(t, &RadiusAuth{Servers: []string{addr}, Secret: "secret"})
+	ra := newProvisioned(t, testRA(addr, "secret"))
 
 	// mock server accepts when user == pass
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -113,7 +131,7 @@ func TestServeHTTP_WrongPassword_Returns401(t *testing.T) {
 	addr, shutdown := startMockRADIUS(t, "secret")
 	defer shutdown()
 
-	ra := newProvisioned(t, &RadiusAuth{Servers: []string{addr}, Secret: "secret"})
+	ra := newProvisioned(t, testRA(addr, "secret"))
 
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	r.SetBasicAuth("alice", "wrongpass")
@@ -129,11 +147,9 @@ func TestServeHTTP_ExceptPath_Bypasses(t *testing.T) {
 	addr, shutdown := startMockRADIUS(t, "secret")
 	defer shutdown()
 
-	ra := newProvisioned(t, &RadiusAuth{
-		Servers:     []string{addr},
-		Secret:      "secret",
-		ExceptPaths: []string{"/public"},
-	})
+	cfg := testRA(addr, "secret")
+	cfg.ExceptPaths = []string{"/public"}
+	ra := newProvisioned(t, cfg)
 
 	r := httptest.NewRequest(http.MethodGet, "/public/file.js", nil)
 	// no credentials
@@ -149,11 +165,9 @@ func TestServeHTTP_OnlyPath_AuthenticatesMatched(t *testing.T) {
 	addr, shutdown := startMockRADIUS(t, "secret")
 	defer shutdown()
 
-	ra := newProvisioned(t, &RadiusAuth{
-		Servers:   []string{addr},
-		Secret:    "secret",
-		OnlyPaths: []string{"/admin"},
-	})
+	cfg := testRA(addr, "secret")
+	cfg.OnlyPaths = []string{"/admin"}
+	ra := newProvisioned(t, cfg)
 
 	// /public should NOT require auth
 	r := httptest.NewRequest(http.MethodGet, "/public", nil)
@@ -177,12 +191,10 @@ func TestServeHTTP_Cache_HitSkipsRADIUS(t *testing.T) {
 	addr, shutdown := startMockRADIUS(t, "secret")
 	defer shutdown()
 
-	ra := newProvisioned(t, &RadiusAuth{
-		Servers:      []string{addr},
-		Secret:       "secret",
-		CachePath:    dir,
-		CacheTimeout: caddy.Duration(5 * time.Minute),
-	})
+	cfg := testRA(addr, "secret")
+	cfg.CachePath = dir
+	cfg.CacheTimeout = caddy.Duration(5 * time.Minute)
+	ra := newProvisioned(t, cfg)
 
 	// First request populates the cache
 	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -205,24 +217,212 @@ func TestServeHTTP_Cache_HitSkipsRADIUS(t *testing.T) {
 	}
 }
 
+// ── Rate limiting tests ──────────────────────────────────────────────────────
+
+func TestRateLimit_BlocksAfterMaxFailures(t *testing.T) {
+	addr, shutdown := startMockRADIUS(t, "secret")
+	defer shutdown()
+
+	cfg := testRA(addr, "secret")
+	cfg.MaxFailures = 3
+	cfg.FailureWindow = caddy.Duration(time.Minute)
+	ra := newProvisioned(t, cfg)
+
+	// Send 3 failed attempts (max_failures = 3)
+	for i := 0; i < 3; i++ {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.SetBasicAuth("alice", "wrongpass")
+		r.RemoteAddr = "10.0.0.1:12345"
+		w := httptest.NewRecorder()
+		ra.ServeHTTP(w, r, okHandler)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: got %d, want 401", i+1, w.Code)
+		}
+	}
+
+	// 4th attempt should be rate-limited — 429 without touching RADIUS
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetBasicAuth("alice", "alice") // even valid creds should be blocked
+	r.RemoteAddr = "10.0.0.1:12345"
+	w := httptest.NewRecorder()
+	ra.ServeHTTP(w, r, okHandler)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("blocked request: got %d, want 429", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on 429")
+	}
+}
+
+func TestRateLimit_DifferentIPsAreIndependent(t *testing.T) {
+	addr, shutdown := startMockRADIUS(t, "secret")
+	defer shutdown()
+
+	cfg := testRA(addr, "secret")
+	cfg.MaxFailures = 2
+	cfg.FailureWindow = caddy.Duration(time.Minute)
+	ra := newProvisioned(t, cfg)
+
+	// Exhaust failures from IP-A
+	for i := 0; i < 2; i++ {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.SetBasicAuth("x", "wrong")
+		r.RemoteAddr = "10.0.0.1:1111"
+		w := httptest.NewRecorder()
+		ra.ServeHTTP(w, r, okHandler)
+	}
+
+	// IP-B should still be able to authenticate
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetBasicAuth("alice", "alice")
+	r.RemoteAddr = "10.0.0.2:2222"
+	w := httptest.NewRecorder()
+	ra.ServeHTTP(w, r, okHandler)
+	if w.Code != http.StatusOK {
+		t.Errorf("IP-B should not be blocked: got %d", w.Code)
+	}
+}
+
+func TestRateLimit_SuccessClearsFailures(t *testing.T) {
+	addr, shutdown := startMockRADIUS(t, "secret")
+	defer shutdown()
+
+	cfg := testRA(addr, "secret")
+	cfg.MaxFailures = 3
+	cfg.FailureWindow = caddy.Duration(time.Minute)
+	ra := newProvisioned(t, cfg)
+
+	// 2 failures
+	for i := 0; i < 2; i++ {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.SetBasicAuth("alice", "wrong")
+		r.RemoteAddr = "10.0.0.1:1111"
+		w := httptest.NewRecorder()
+		ra.ServeHTTP(w, r, okHandler)
+	}
+
+	// Successful auth clears the counter
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetBasicAuth("alice", "alice")
+	r.RemoteAddr = "10.0.0.1:1111"
+	w := httptest.NewRecorder()
+	ra.ServeHTTP(w, r, okHandler)
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid login: got %d, want 200", w.Code)
+	}
+
+	// 3 more failures should be allowed (counter was reset)
+	for i := 0; i < 3; i++ {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.SetBasicAuth("alice", "wrong")
+		r.RemoteAddr = "10.0.0.1:1111"
+		w := httptest.NewRecorder()
+		ra.ServeHTTP(w, r, okHandler)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("post-reset attempt %d: got %d, want 401", i+1, w.Code)
+		}
+	}
+}
+
+func TestRateLimit_WindowExpiry(t *testing.T) {
+	addr, shutdown := startMockRADIUS(t, "secret")
+	defer shutdown()
+
+	cfg := testRA(addr, "secret")
+	cfg.MaxFailures = 1
+	cfg.FailureWindow = caddy.Duration(5 * time.Millisecond)
+	ra := newProvisioned(t, cfg)
+
+	// One failure blocks the IP
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r1.SetBasicAuth("x", "wrong")
+	r1.RemoteAddr = "10.0.0.1:1111"
+	w1 := httptest.NewRecorder()
+	ra.ServeHTTP(w1, r1, okHandler)
+
+	// Confirm blocked
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.SetBasicAuth("alice", "alice")
+	r2.RemoteAddr = "10.0.0.1:1111"
+	w2 := httptest.NewRecorder()
+	ra.ServeHTTP(w2, r2, okHandler)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("should be blocked: got %d", w2.Code)
+	}
+
+	// Wait for window to expire
+	time.Sleep(10 * time.Millisecond)
+
+	// Should be unblocked now
+	r3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r3.SetBasicAuth("alice", "alice")
+	r3.RemoteAddr = "10.0.0.1:1111"
+	w3 := httptest.NewRecorder()
+	ra.ServeHTTP(w3, r3, okHandler)
+	if w3.Code != http.StatusOK {
+		t.Errorf("window expired, should be unblocked: got %d", w3.Code)
+	}
+}
+
+// ── Rate limiter unit tests ──────────────────────────────────────────────────
+
+func TestExtractIP(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"1.2.3.4:8080", "1.2.3.4"},
+		{"[::1]:80", "::1"},
+		{"1.2.3.4", "1.2.3.4"},
+	}
+	for _, tc := range cases {
+		if got := extractIP(tc.input); got != tc.want {
+			t.Errorf("extractIP(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestCleanupLoop_RemovesExpiredEntries(t *testing.T) {
+	rl := &rateLimiter{
+		failures: make(map[string]*failRecord),
+		stop:     make(chan struct{}),
+	}
+	window := 5 * time.Millisecond
+	go rl.cleanupLoop(window)
+	defer close(rl.stop)
+
+	rl.recordFailure("10.0.0.1", window)
+	rl.recordFailure("10.0.0.2", window)
+
+	// Wait for window + one sweep cycle
+	time.Sleep(15 * time.Millisecond)
+
+	rl.mu.Lock()
+	remaining := len(rl.failures)
+	rl.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("cleanup should have removed all entries, %d remain", remaining)
+	}
+}
+
 // ── Validate tests ────────────────────────────────────────────────────────────
 
 func TestValidate_MissingServer(t *testing.T) {
-	ra := &RadiusAuth{Secret: "s"}
+	ra := &RadiusAuth{Secret: "s", MaxFailures: 5, FailureWindow: caddy.Duration(time.Minute)}
 	if err := ra.Validate(); err == nil {
 		t.Error("expected error for missing servers")
 	}
 }
 
 func TestValidate_MissingSecret(t *testing.T) {
-	ra := &RadiusAuth{Servers: []string{"127.0.0.1:1812"}}
+	ra := &RadiusAuth{Servers: []string{"127.0.0.1:1812"}, MaxFailures: 5, FailureWindow: caddy.Duration(time.Minute)}
 	if err := ra.Validate(); err == nil {
 		t.Error("expected error for missing secret")
 	}
 }
 
 func TestValidate_BadServerAddr(t *testing.T) {
-	ra := &RadiusAuth{Servers: []string{"notanaddress"}, Secret: "s"}
+	ra := &RadiusAuth{Servers: []string{"notanaddress"}, Secret: "s", MaxFailures: 5, FailureWindow: caddy.Duration(time.Minute)}
 	if err := ra.Validate(); err == nil {
 		t.Error("expected error for bad server address")
 	}
@@ -230,18 +430,47 @@ func TestValidate_BadServerAddr(t *testing.T) {
 
 func TestValidate_ConflictingFilters(t *testing.T) {
 	ra := &RadiusAuth{
-		Servers:     []string{"127.0.0.1:1812"},
-		Secret:      "s",
-		ExceptPaths: []string{"/pub"},
-		OnlyPaths:   []string{"/admin"},
+		Servers:       []string{"127.0.0.1:1812"},
+		Secret:        "s",
+		ExceptPaths:   []string{"/pub"},
+		OnlyPaths:     []string{"/admin"},
+		MaxFailures:   5,
+		FailureWindow: caddy.Duration(time.Minute),
 	}
 	if err := ra.Validate(); err == nil {
 		t.Error("expected error for both except and only")
 	}
 }
 
+func TestValidate_MissingMaxFailures(t *testing.T) {
+	ra := &RadiusAuth{
+		Servers:       []string{"127.0.0.1:1812"},
+		Secret:        "s",
+		FailureWindow: caddy.Duration(time.Minute),
+	}
+	if err := ra.Validate(); err == nil {
+		t.Error("expected error for missing max_failures")
+	}
+}
+
+func TestValidate_MissingFailureWindow(t *testing.T) {
+	ra := &RadiusAuth{
+		Servers:     []string{"127.0.0.1:1812"},
+		Secret:      "s",
+		MaxFailures: 5,
+	}
+	if err := ra.Validate(); err == nil {
+		t.Error("expected error for missing failure_window")
+	}
+}
+
 func TestValidate_Valid(t *testing.T) {
-	ra := &RadiusAuth{Servers: []string{"127.0.0.1:1812"}, Secret: "s"}
+	ra := &RadiusAuth{
+		Servers:       []string{"127.0.0.1:1812"},
+		Secret:        "s",
+		MaxFailures:   5,
+		FailureWindow: caddy.Duration(time.Minute),
+	}
 	if err := ra.Validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -257,6 +486,8 @@ func TestUnmarshalCaddyfile_Basic(t *testing.T) {
 		cache /tmp
 		cache_timeout 10m
 		except /health /metrics
+		max_failures 5
+		failure_window 1m
 	}`
 
 	d := caddyfile.NewTestDispenser(input)
@@ -282,6 +513,12 @@ func TestUnmarshalCaddyfile_Basic(t *testing.T) {
 	}
 	if len(ra.ExceptPaths) != 2 {
 		t.Errorf("except paths: %v", ra.ExceptPaths)
+	}
+	if ra.MaxFailures != 5 {
+		t.Errorf("max_failures: %d", ra.MaxFailures)
+	}
+	if time.Duration(ra.FailureWindow) != time.Minute {
+		t.Errorf("failure_window: %v", ra.FailureWindow)
 	}
 }
 
@@ -314,6 +551,23 @@ func TestUnmarshalCaddyfile_CacheTimeoutSeconds(t *testing.T) {
 	}
 	if time.Duration(ra.CacheTimeout) != 300*time.Second {
 		t.Errorf("want 300s, got %v", ra.CacheTimeout)
+	}
+}
+
+func TestUnmarshalCaddyfile_FailureWindowSeconds(t *testing.T) {
+	// backwards-compat: plain integer = seconds
+	input := `radiusauth {
+		server 127.0.0.1:1812
+		secret s
+		failure_window 60
+	}`
+	d := caddyfile.NewTestDispenser(input)
+	ra := &RadiusAuth{}
+	if err := ra.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile: %v", err)
+	}
+	if time.Duration(ra.FailureWindow) != 60*time.Second {
+		t.Errorf("want 60s, got %v", ra.FailureWindow)
 	}
 }
 

--- a/radius_test.go
+++ b/radius_test.go
@@ -344,7 +344,8 @@ func TestIgnoredPathFilter(t *testing.T) {
 		{"/public", false},
 		{"/public/file.js", false},
 		{"/health", false},
-		{"/healthz", false}, // HasPrefix: /healthz starts with /health
+		{"/health/check", false},
+		{"/healthz", true}, // segment-aware: /healthz is not under /health
 	}
 	for _, tc := range cases {
 		r := httptest.NewRequest(http.MethodGet, tc.path, nil)
@@ -366,7 +367,7 @@ func TestSecuredPathFilter(t *testing.T) {
 		{"/admin", true},
 		{"/admin/users", true},
 		{"/api/v1", true},
-		{"/apiold", true}, // HasPrefix match
+		{"/apiold", false}, // segment-aware: /apiold is not under /api
 	}
 	for _, tc := range cases {
 		r := httptest.NewRequest(http.MethodGet, tc.path, nil)

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,110 @@
+package radiusauth
+
+// Rate limiting protects RADIUS infrastructure from brute-force attacks.
+//
+// RADIUS servers are shared authentication backends. Without rate limiting,
+// an attacker can make unlimited authentication attempts through this module,
+// both brute-forcing credentials and overwhelming the RADIUS server(s).
+//
+// This in-memory rate limiter blocks repeat offenders before any RADIUS
+// packet is sent, protecting both credentials and backend infrastructure.
+// The max_failures and failure_window fields are mandatory in the Caddyfile
+// to ensure operators cannot accidentally deploy without brute-force protection.
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// failRecord tracks failed authentication attempts from a single IP.
+type failRecord struct {
+	count       int
+	windowStart time.Time
+}
+
+// rateLimiter tracks per-IP authentication failures.
+//
+// This is allocated as a pointer field in RadiusAuth so that the
+// value-receiver ServeHTTP (which copies the RadiusAuth struct on
+// every request) still shares the same map and mutex. If this field
+// is ever changed from a pointer to a value, rate limiting will
+// silently break — every request would get its own empty map.
+type rateLimiter struct {
+	mu       sync.Mutex
+	failures map[string]*failRecord
+	stop     chan struct{}
+}
+
+// isBlocked returns true if the given IP has exceeded maxFailures
+// within the current window.
+func (rl *rateLimiter) isBlocked(ip string, maxFailures int, window time.Duration) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	rec, ok := rl.failures[ip]
+	if !ok {
+		return false
+	}
+	if time.Since(rec.windowStart) > window {
+		delete(rl.failures, ip)
+		return false
+	}
+	return rec.count >= maxFailures
+}
+
+// recordFailure increments the failure count for the given IP.
+// If the existing window has expired, a new window is started.
+func (rl *rateLimiter) recordFailure(ip string, window time.Duration) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	rec, ok := rl.failures[ip]
+	if !ok || time.Since(rec.windowStart) > window {
+		rl.failures[ip] = &failRecord{count: 1, windowStart: time.Now()}
+		return
+	}
+	rec.count++
+}
+
+// clearFailures removes the failure record for an IP after a
+// successful authentication, resetting their counter to zero.
+func (rl *rateLimiter) clearFailures(ip string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	delete(rl.failures, ip)
+}
+
+// cleanupLoop periodically removes expired entries from the failure map
+// to prevent unbounded memory growth from long-gone attackers.
+func (rl *rateLimiter) cleanupLoop(window time.Duration) {
+	ticker := time.NewTicker(window)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			rl.mu.Lock()
+			now := time.Now()
+			for ip, rec := range rl.failures {
+				if now.Sub(rec.windowStart) > window {
+					delete(rl.failures, ip)
+				}
+			}
+			rl.mu.Unlock()
+		case <-rl.stop:
+			return
+		}
+	}
+}
+
+// extractIP returns the IP portion of a RemoteAddr string,
+// stripping the port. Handles IPv4 ("1.2.3.4:8080"),
+// IPv6 ("[::1]:8080"), and bare addresses ("1.2.3.4").
+func extractIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}


### PR DESCRIPTION
**Per-IP brute-force rate limiting (49da7d7)**

Adds mandatory max_failures and failure_window options that block IPs after repeated failed authentications. The rate limiter sits in front of credential parsing — blocked IPs get 429 before any RADIUS packet is sent, protecting both credentials and backend RADIUS infrastructure from flooding. Successful auth resets the counter. In-memory with a backgroun cleanup goroutine.

**Segment-aware path filtering (e8862c7)**

Fixes a bug where except /api would also skip auth for /api-docs, /apiold, etc. Path matching now requires an exact match or a / segment boundary — /api matches /api and /api/v1 but not /apiold.

Both changes include full test coverage (31 total, all pass with -race).