### PR TITLE
Use per-server timeout for RADIUS failover

### DIFF
--- a/radius.go
+++ b/radius.go
@@ -236,12 +236,13 @@ func (ra RadiusAuth) radiusAuth(username, password string) (bool, error) {
 	rfc2865.UserPassword_SetString(packet, password)
 	rfc2865.NASIdentifier_SetString(packet, ra.NASID)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
+	// Per-server timeout ensures each server gets its own time budget.
+	// A single shared timeout would let one slow server starve failover.
 	var lastErr error
 	for _, server := range ra.Servers {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		reply, err := radius.Exchange(ctx, packet, server)
+		cancel()
 		if err != nil {
 			ra.logger.Warn("RADIUS server unreachable", zap.String("server", server), zap.Error(err))
 			lastErr = err

--- a/radius_test.go
+++ b/radius_test.go
@@ -186,6 +186,32 @@ func TestServeHTTP_OnlyPath_AuthenticatesMatched(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_FailoverToSecondServer(t *testing.T) {
+	// First server is an address that will timeout (nothing listening).
+	// Second server is the working mock. With per-server timeouts, the
+	// second server should still respond within its own 5s budget.
+	deadAddr := "127.0.0.1:19999" // nothing listening here
+	liveAddr, shutdown := startMockRADIUS(t, "secret")
+	defer shutdown()
+
+	cfg := &RadiusAuth{
+		Servers:       []string{deadAddr, liveAddr},
+		Secret:        "secret",
+		MaxFailures:   testMaxFailures,
+		FailureWindow: testFailureWindow,
+	}
+	ra := newProvisioned(t, cfg)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetBasicAuth("alice", "alice")
+	w := httptest.NewRecorder()
+	ra.ServeHTTP(w, r, okHandler)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("failover: got %d, want 200", w.Code)
+	}
+}
+
 func TestServeHTTP_Cache_HitSkipsRADIUS(t *testing.T) {
 	dir := t.TempDir()
 	addr, shutdown := startMockRADIUS(t, "secret")


### PR DESCRIPTION
A single shared 10s context.WithTimeout across all servers meant a slow/unresponsive first server could consume the entire budget, leaving zero time for failover. Each server now gets its own 5s timeout so failover actually works.

cancel() is called inline (not deferred) since defer in a loop would leak contexts until the function returns.

